### PR TITLE
Fix FTBFS with GCC-10

### DIFF
--- a/src/medusa.c
+++ b/src/medusa.c
@@ -37,6 +37,11 @@ int nModuleParamCount;    // the "argc" for the module
 //int ctrlc = 0;
 sAudit *psAudit = NULL;
 
+int iVerboseLevel;
+int iErrorLevel;
+FILE *pOutputFile;
+pthread_mutex_t ptmFileMutex;
+
 void freeModuleParams()
 {
   int i;

--- a/src/medusa.h
+++ b/src/medusa.h
@@ -63,10 +63,10 @@
 #define TRUE 1
 
 /* GLOBAL VARIABLES */
-FILE *pOutputFile;
-pthread_mutex_t ptmFileMutex;
-int iVerboseLevel;      // Global control over general message verbosity
-int iErrorLevel;        // Global control over error debugging verbosity
+extern FILE *pOutputFile;
+extern pthread_mutex_t ptmFileMutex;
+extern int iVerboseLevel;      // Global control over general message verbosity
+extern int iErrorLevel;        // Global control over error debugging verbosity
 
 //#define MAX_BUF (16 * 1024)
 #define MAX_BUF 16384 


### PR DESCRIPTION
Medusa fails to build from source with GCC-10 in Debian with:
```
/usr/bin/ld: /usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:68: multiple definition of `iVerboseLevel'; ../medusa-trace.o:./src/modsrc/../medusa.h:68: multiple definition of `iVerboseLevel'; cvs.o:./src/modsrc/../medusa.h:68: first defined here
/usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:66: multiple definition of `pOutputFile'; cvs.o:./src/modsrc/../medusa.h:66: first defined here
/usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:67: multiple definition of `ptmFileMutex'; cvs.o:./src/modsrc/../medusa.h:ftp.o:./src/modsrc/../medusa.h:68: first defined here
/usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:66: multiple definition of `pOutputFile'; ftp.o:./src/modsrc/../medusa.h:66: first defined here
/usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:67: multiple definition of `ptmFileMutex'; ftp.o:./src/modsrc/../medusa.h:67: first defined here
/usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:69: multiple definition of `iErrorLevel'; ftp.o:./src/modsrc/../medusa.h:69: first defined here
gcc  -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wl,-z,relro -Wl,-z,now -L/usr/local/lib -L/usr//lib -rdynamic  -o http.mod http.o ntlm.o http-digest.o ../medusa-trace.o -lpq  -lssh2 -lsvn_client-1 -shared -ldl -lpthread  -lssl -lcrypto -lssl -lcrypto -lgcrypt -lgnutls -ldl -lrt -lm
67: first defined here
/usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:69: multiple definition of `iErrorLevel'; cvs.o:./src/modsrc/../medusa.h:69: first defined here
/usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:68: multiple definition of `iVerboseLevel'; http.o:./src/modsrc/../medusa.h:68: first defined here
/usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:66: multiple definition of `pOutputFile'; http.o:./src/modsrc/../medusa.h:66: first defined here
/usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:67: multiple definition of `ptmFileMutex'; http.o:./src/modsrc/../medusa.h:67: first defined here
/usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:69: multiple definition of `iErrorLevel'; http.o:./src/modsrc/../medusa.h:69: first defined here
gcc  -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Wl,-z,relro -Wl,-z,now -L/usr/local/lib -L/usr//lib -rdynamic  -o imap.mod imap.o ntlm.o ../medusa-trace.o -lpq  -lssh2 -lsvn_client-1 -shared -ldl -lpthread  -lssl -lcrypto -lssl -lcrypto -lgcrypt -lgnutls -ldl -lrt -lm
/usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:68: multiple definition of `iVerboseLevel'; imap.o:./src/modsrc/../medusa.h:68: first defined here
/usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:66: multiple definition of `pOutputFile'; imap.o:./src/modsrc/../medusa.h:66: first defined here
/usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:67: multiple definition of `ptmFileMutex'; imap.o:./src/modsrc/../medusa.h:67: first defined here
/usr/bin/ld: ../medusa-trace.o:./src/modsrc/../medusa.h:69: multiple definition of `iErrorLevel'; imap.o:./src/modsrc/../medusa.h:69: first defined here
collect2: error: ld returned 1 exit status
make[4]: *** [Makefile:696: cvs.mod] Error 1
```
I found information about GCC 10 changes here:
https://www.gnu.org/software/gcc/gcc-10/porting_to.html