### PR TITLE
Source fortify fixes

### DIFF
--- a/src/listModules.c
+++ b/src/listModules.c
@@ -73,10 +73,7 @@ void listModules(char* arrPaths[], int nTerminateNow)
     }
     else
     {
-      iLength = strlen( pszDir ) + 1;
-      pszTarget = (char*)malloc( iLength );
-      memset( pszTarget, 0, iLength );
-      strncpy( pszTarget, pszDir, strlen(pszDir) );
+      pszTarget = strdup(pszDir);
       iLength = 0;
     }  /*  (was a directory specified?)  */
       

--- a/src/listModules.c
+++ b/src/listModules.c
@@ -103,9 +103,9 @@ void listModules(char* arrPaths[], int nTerminateNow)
             iLength = strlen( pdeEntry[j]->d_name ) + strlen( pszTarget ) + 2;
             pszLibName = (char*)malloc( iLength );
             memset( pszLibName, 0, iLength );
-            strncpy( pszLibName, pszTarget, strlen(pszTarget) );
-            strncat( pszLibName, "/", 1 );
-            strncat( pszLibName, pdeEntry[j]->d_name, strlen(pdeEntry[j]->d_name) );
+            strcpy(pszLibName, pszTarget);
+            strcat(pszLibName, "/");
+            strcat(pszLibName, pdeEntry[j]->d_name);
   
             /*  Load this as a shared library  */
             pLibrary = dlopen( pszLibName, RTLD_NOW );

--- a/src/medusa.c
+++ b/src/medusa.c
@@ -142,9 +142,7 @@ int checkOptions(int argc, char **argv, sAudit *_psAudit)
       }
       else
       {
-        _psAudit->pGlobalHost = malloc( strlen(optarg) + 1 );
-        memset(_psAudit->pGlobalHost, 0, strlen(optarg) + 1);
-        strncpy(_psAudit->pGlobalHost, optarg, strlen(optarg));
+        _psAudit->pGlobalHost = strdup(optarg);
         _psAudit->HostType = L_SINGLE;
       }
       break;
@@ -156,9 +154,7 @@ int checkOptions(int argc, char **argv, sAudit *_psAudit)
       }
       else
       {
-        _psAudit->pOptHost = malloc( strlen(optarg) + 1 );
-        memset(_psAudit->pOptHost, 0, strlen(optarg) + 1);
-        strncpy(_psAudit->pOptHost, optarg, strlen(optarg));
+        _psAudit->pOptHost = strdup(optarg);
         _psAudit->HostType = L_FILE;
       }
       break;
@@ -170,9 +166,7 @@ int checkOptions(int argc, char **argv, sAudit *_psAudit)
       }
       else
       {
-        _psAudit->pGlobalUser = malloc( strlen(optarg) + 1 );
-        memset(_psAudit->pGlobalUser, 0, strlen(optarg) + 1);
-        strncpy(_psAudit->pGlobalUser, optarg, strlen(optarg));
+        _psAudit->pGlobalUser = strdup(optarg);
         _psAudit->UserType = L_SINGLE;
         _psAudit->iUserCnt = 1;
       }
@@ -185,9 +179,7 @@ int checkOptions(int argc, char **argv, sAudit *_psAudit)
       }
       else
       {
-        _psAudit->pOptUser = malloc( strlen(optarg) + 1 );
-        memset(_psAudit->pOptUser, 0, strlen(optarg) + 1);
-        strncpy(_psAudit->pOptUser, optarg, strlen(optarg));
+        _psAudit->pOptUser = strdup(optarg);
         _psAudit->UserType = L_FILE;
       }
       break;
@@ -214,21 +206,15 @@ int checkOptions(int argc, char **argv, sAudit *_psAudit)
       }
       else
       {
-        _psAudit->pOptPass = malloc( strlen(optarg) + 1 );
-        memset(_psAudit->pOptPass, 0, strlen(optarg) + 1);
-        strncpy(_psAudit->pOptPass, optarg, strlen(optarg));
+        _psAudit->pOptPass = strdup(optarg);
         _psAudit->PassType = L_FILE;
       }
       break;
     case 'C':
-      _psAudit->pOptCombo = malloc( strlen(optarg) + 1 );
-      memset(_psAudit->pOptCombo, 0, strlen(optarg) + 1);
-      strncpy(_psAudit->pOptCombo, optarg, strlen(optarg));
+      _psAudit->pOptCombo = strdup(optarg);
       break;
     case 'O':
-      _psAudit->pOptOutput = malloc( strlen(optarg) + 1 );
-      memset(_psAudit->pOptOutput, 0, strlen(optarg) + 1);
-      strncpy(_psAudit->pOptOutput, optarg, strlen(optarg));
+      _psAudit->pOptOutput = strdup(optarg);
       break;
     case 'e':
       if (strcmp(optarg, "n") == 0)
@@ -283,16 +269,12 @@ int checkOptions(int argc, char **argv, sAudit *_psAudit)
       writeVerbose(VB_EXIT, "");  // Terminate now
       break;
     case 'M':
-      szModuleName = malloc(strlen(optarg) + 1);
-      memset(szModuleName, 0, strlen(optarg) + 1);
-      strncpy(szModuleName, optarg, strlen(optarg));
+      szModuleName = strdup(optarg);
       _psAudit->pModuleName = szModuleName;
       break;
     case 'm':
       nModuleParamCount++;
-      szTempModuleParam = malloc(strlen(optarg) + 1);
-      memset(szTempModuleParam, 0, strlen(optarg) + 1);
-      strncpy(szTempModuleParam, optarg, strlen(optarg));
+      szTempModuleParam = strdup(optarg);
       arrModuleParams = realloc(arrModuleParams, nModuleParamCount * sizeof(char*));
       arrModuleParams[nModuleParamCount - 1] = szTempModuleParam;
       break;
@@ -318,9 +300,7 @@ int checkOptions(int argc, char **argv, sAudit *_psAudit)
       _psAudit->iSocketWait = atoi(optarg);
       break;
     case 'Z':
-      _psAudit->pOptResume = malloc( strlen(optarg) + 1 );
-      memset(_psAudit->pOptResume, 0, strlen(optarg) + 1);
-      strncpy(_psAudit->pOptResume, optarg, strlen(optarg));
+      _psAudit->pOptResume = strdup(optarg);
       break;
     default:
       writeError(ERR_CRITICAL, "Unknown error processing command-line options.");
@@ -957,9 +937,7 @@ int loadLoginInfo(sAudit *_psAudit)
         psHostPrevTmp = psHost;
       }
 
-      psHost->pHost = malloc( strlen(pHost) + 1 );
-      memset(psHost->pHost, 0, strlen(pHost) + 1);
-      strncpy(psHost->pHost, pHost, strlen(pHost) + 1);
+      psHost->pHost = strdup(pHost);
       psHost->iPortOverride = _psAudit->iPortOverride;
       psHost->iUseSSL = _psAudit->iUseSSL;
       psHost->iTimeout = _psAudit->iTimeout;
@@ -1001,9 +979,7 @@ int loadLoginInfo(sAudit *_psAudit)
 
         psHost->psUserPrevTmp = psUser;
 
-        psUser->pUser = malloc( strlen(pUser) + 1 );
-        memset(psUser->pUser, 0, strlen(pUser) + 1);
-        strncpy(psUser->pUser, pUser, strlen(pUser));
+        psUser->pUser = strdup(pUser);
         psUser->iPassCnt = _psAudit->iPassCnt;
         psUser->iPassStatus = PL_UNSET;
         psUser->iId = psHost->iUserCnt;
@@ -1025,9 +1001,7 @@ int loadLoginInfo(sAudit *_psAudit)
       {
         psPass = malloc(sizeof(sPass));
         memset(psPass, 0, sizeof(sPass));
-        psPass->pPass = malloc( strlen(pPass) + 1 );
-        memset(psPass->pPass, 0, strlen(pPass) + 1);
-        strncpy(psPass->pPass, pPass, strlen(pPass));
+        psPass->pPass = strdup(pPass);
         psUser->iPassCnt++;
         psHost->iUserPassCnt++;
 
@@ -1477,9 +1451,7 @@ int addMissedCredSet(sLogin *_psLogin, sCredentialSet *_psCredSet)
   
   psCredSetMissed->psUser = _psCredSet->psUser;
 
-  psCredSetMissed->pPass = malloc(strlen(_psCredSet->pPass) + 1);
-  memset(psCredSetMissed->pPass, 0, strlen(_psCredSet->pPass) + 1);
-  strncpy(psCredSetMissed->pPass, _psCredSet->pPass, strlen(_psCredSet->pPass));
+  psCredSetMissed->pPass = strdup(_psCredSet->pPass);
 
   /* append structure to host's list of missed credentials */
   if (_psLogin->psServer->psCredentialSetMissed == NULL) /* first missed credential set */

--- a/src/medusa.c
+++ b/src/medusa.c
@@ -193,7 +193,7 @@ int checkOptions(int argc, char **argv, sAudit *_psAudit)
       {
         _psAudit->pGlobalPass = malloc( strlen(optarg) + 2 );
         memset(_psAudit->pGlobalPass, 0, strlen(optarg) + 2);
-        strncpy(_psAudit->pGlobalPass, optarg, strlen(optarg));
+        strcpy(_psAudit->pGlobalPass, optarg);
         _psAudit->PassType = L_SINGLE;
         _psAudit->iPassCnt = 1;
       }
@@ -375,10 +375,10 @@ int invokeModule(char* pModuleName, sLogin* pLogin, int argc, char* argv[])
       nPathLength = strlen(szModulePaths[i]) + strlen(pModuleName) + strlen(MODULE_EXTENSION) + 2;  // Going to add a slash too
       modPath = malloc(nPathLength);
       memset(modPath, 0, nPathLength);
-      strncpy(modPath, szModulePaths[i], strlen(szModulePaths[i]));
-      strncat(modPath, "/", 1);
-      strncat(modPath, pModuleName, strlen(pModuleName));
-      strncat(modPath, MODULE_EXTENSION, strlen(MODULE_EXTENSION));
+      strcpy(modPath, szModulePaths[i]);
+      strcat(modPath, "/");
+      strcat(modPath, pModuleName);
+      strcat(modPath, MODULE_EXTENSION);
 
       // Now try the load
       writeError(ERR_DEBUG, "Attempting to load %s", modPath);

--- a/src/modsrc/cvs.c
+++ b/src/modsrc/cvs.c
@@ -118,9 +118,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);
@@ -132,9 +130,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szDir = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szDir, 0, (strlen(pOpt) + 1));
-          strncpy((char *)psSessionData->szDir, pOpt, strlen(pOpt));
+          psSessionData->szDir = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method DIR requires value to be set.");
@@ -310,9 +306,7 @@ int tryLogin(int hSocket, sLogin** psLogin, _CVS_DATA* _psSessionData, char* szL
     return FAILURE;
   }
 
-  szPassTmp = malloc(strlen(szPassword) + 1);
-  memset(szPassTmp, 0, strlen(szPassword) + 1);
-  strncpy(szPassTmp, szPassword, strlen(szPassword));
+  szPassTmp = strdup(szPassword);
 
   for (i = 0; i < strlen(szPassTmp); i++)
     szPassTmp[i] = key[szPassTmp[i] - 0x20];

--- a/src/modsrc/ftp.c
+++ b/src/modsrc/ftp.c
@@ -147,9 +147,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
  
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);

--- a/src/modsrc/http.c
+++ b/src/modsrc/http.c
@@ -146,9 +146,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);
@@ -160,9 +158,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szDir = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szDir, 0, strlen(pOpt) + 1);
-          strncpy(psSessionData->szDir, pOpt, strlen(pOpt) + 1);
+          psSessionData->szDir = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method DIR requires value to be set.");
@@ -174,9 +170,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szUserAgent = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szUserAgent, 0, strlen(pOpt) + 1);
-          strncpy(psSessionData->szUserAgent, pOpt, strlen(pOpt) + 1);
+          psSessionData->szUserAgent = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method USER-AGENT requires value to be set.");
@@ -224,9 +218,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szDomain = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szDomain, 0, strlen(pOpt) + 1);
-          strncpy((char *) psSessionData->szDomain, pOpt, strlen(pOpt));
+          psSessionData->szDomain = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method DOMAIN requires value to be set.");
@@ -642,9 +634,7 @@ int sendAuthDigest(int hSocket, _MODULE_DATA* _psSessionData, char* szLogin, cha
   /* URI should start with a "/" */
   if (strncmp(_psSessionData->szDir, "/", 1) == 0) 
   {
-    szURI = malloc(strlen(_psSessionData->szDir) + 1);
-    memset(szURI, 0, strlen(_psSessionData->szDir) + 1);
-    strncat(szURI, _psSessionData->szDir, strlen(_psSessionData->szDir));
+    szURI = strdup(_psSessionData->szDir);
   }
   else
   {

--- a/src/modsrc/http.c
+++ b/src/modsrc/http.c
@@ -640,8 +640,8 @@ int sendAuthDigest(int hSocket, _MODULE_DATA* _psSessionData, char* szLogin, cha
   {
     szURI = malloc(1 + strlen(_psSessionData->szDir) + 1);
     memset(szURI, 0, 1 + strlen(_psSessionData->szDir) + 1);
-    strncat(szURI, "/", 1);
-    strncat(szURI, _psSessionData->szDir, strlen(_psSessionData->szDir));
+    strcpy(szURI, "/");
+    strcat(szURI, _psSessionData->szDir);
   }
 
   /* Send initial request */

--- a/src/modsrc/imap.c
+++ b/src/modsrc/imap.c
@@ -151,9 +151,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);
@@ -165,9 +163,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szTag = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szTag, 0, strlen(pOpt) + 1);
-          strncpy(psSessionData->szTag, pOpt, strlen(pOpt) + 1);
+          psSessionData->szTag = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method TAG requires value to be set.");
@@ -195,9 +191,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szDomain = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szDomain, 0, strlen(pOpt) + 1); 
-          strncpy((char *) psSessionData->szDomain, pOpt, strlen(pOpt));
+          psSessionData->szDomain = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method DOMAIN requires value to be set.");

--- a/src/modsrc/mysql.c
+++ b/src/modsrc/mysql.c
@@ -144,9 +144,7 @@ int go(sLogin* logins, int argc, char *argv[])
     psSessionData->hashFlag = PASSWORD;
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);

--- a/src/modsrc/ncp.c
+++ b/src/modsrc/ncp.c
@@ -142,9 +142,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
  
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);

--- a/src/modsrc/ncp.c
+++ b/src/modsrc/ncp.c
@@ -209,8 +209,8 @@ int initModule(sLogin* psLogin, _NCP_DATA *_psSessionData)
         {
           szUserContext = malloc(strlen(psCredSet->psUser->pUser) + strlen(_psSessionData->context) + 1);
           memset(szUserContext, 0, strlen(psCredSet->psUser->pUser) + strlen(_psSessionData->context) + 1);
-          strncpy(szUserContext, psCredSet->psUser->pUser, strlen(psCredSet->psUser->pUser));
-          strncpy(szUserContext + strlen(psCredSet->psUser->pUser), _psSessionData->context, strlen(_psSessionData->context));
+          strcpy(szUserContext, psCredSet->psUser->pUser);
+          strcat(szUserContext, _psSessionData->context);
         }
         else
           szUserContext = psCredSet->psUser->pUser;

--- a/src/modsrc/pcanywhere.c
+++ b/src/modsrc/pcanywhere.c
@@ -367,9 +367,9 @@ int pcaUserAuth(int hSocket, char* szDomain, char* szLogin, char* szPassword)
     
       szTmp = malloc(strlen(szDomain) + 1 + strlen(szLogin) + 1);
       memset(szTmp, 0, strlen(szDomain) + 1 + strlen(szLogin) + 1);
-      strncpy(szTmp, szDomain, strlen(szDomain));
-      memset(szTmp + strlen(szDomain), '\\', 1);
-      strncpy(szTmp + strlen(szDomain) + 1, szLogin, strlen(szLogin));
+      strcpy(szTmp, szDomain);
+      strcat(szTmp, "\\");
+      strcat(szTmp, szLogin);
       pcaEncrypt(szTmp, clogin, 0xAB, 1);
       writeError(ERR_DEBUG_MODULE, "%s: Setting domain\\user value: %s", MODULE_NAME, szTmp);
       FREE(szTmp);

--- a/src/modsrc/pcanywhere.c
+++ b/src/modsrc/pcanywhere.c
@@ -140,9 +140,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);

--- a/src/modsrc/pop3.c
+++ b/src/modsrc/pop3.c
@@ -140,9 +140,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);
@@ -184,9 +182,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szDomain = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szDomain, 0, strlen(pOpt) + 1);
-          strncpy((char *) psSessionData->szDomain, pOpt, strlen(pOpt));
+          psSessionData->szDomain = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method DOMAIN requires value to be set.");

--- a/src/modsrc/postgres.c
+++ b/src/modsrc/postgres.c
@@ -121,9 +121,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);
@@ -135,9 +133,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szDB = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szDB, 0, strlen(pOpt) + 1);
-          strncpy((char *)psSessionData->szDB, pOpt, strlen(pOpt));
+          psSessionData->szDB = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method DB requires value to be set.");

--- a/src/modsrc/rdp.c
+++ b/src/modsrc/rdp.c
@@ -150,9 +150,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);
@@ -164,9 +162,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szDomain = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szDomain, 0, strlen(pOpt) + 1);
-          strncpy((char *) psSessionData->szDomain, pOpt, strlen(pOpt));
+          psSessionData->szDomain = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method DOMAIN requires value to be set.");

--- a/src/modsrc/smbnt.c
+++ b/src/modsrc/smbnt.c
@@ -288,9 +288,7 @@ int go(sLogin* logins, int argc, char *argv[])
     psSessionData->protoFlag = WIN2000_NATIVEMODE;
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);
@@ -534,9 +532,7 @@ char* parseFullyQualifiedUsername(_SMBNT_DATA *_psSessionData, char* szLogin)
       writeError(ERR_NOTICE, "[%s] Using the DOMAIN\\USER format with the GROUP/GROUP_OTHER module options is redundant.", MODULE_NAME);
     }
 
-    pOptTmp = malloc( strlen(szLogin) + 1);
-    memset(pOptTmp, 0, strlen(szLogin) + 1);
-    strncpy(pOptTmp, szLogin, strlen(szLogin));
+    pOptTmp = strdup(szLogin);
     writeError(ERR_DEBUG_MODULE, "Processing domain and username: %s", pOptTmp);
 
     pOpt = strtok_r(pOptTmp, "\\", &strtok_ptr); 
@@ -544,9 +540,7 @@ char* parseFullyQualifiedUsername(_SMBNT_DATA *_psSessionData, char* szLogin)
     writeError(ERR_DEBUG_MODULE, "Processing domain: %s", _psSessionData->workgroup_other);
     
     pOpt = strtok_r(NULL, "\\", &strtok_ptr);
-    szUser = malloc(strlen(pOpt) + 1);
-    memset(szUser, 0, strlen(pOpt) + 1);
-    strncpy(szUser, pOpt, strlen(pOpt));
+    szUser = strdup(pOpt);
     writeError(ERR_DEBUG_MODULE, "Processing username: %s", szUser);
 
     FREE(pOptTmp);
@@ -555,9 +549,7 @@ char* parseFullyQualifiedUsername(_SMBNT_DATA *_psSessionData, char* szLogin)
   }
   else
   {
-    szUser = malloc(strlen(szLogin) + 1); 
-    memset(szUser, 0, strlen(szLogin) + 1);
-    strncpy(szUser, szLogin, strlen(szLogin));
+    szUser = strdup(szLogin);
     writeError(ERR_DEBUG_MODULE, "Processing username: %s", szUser);
   }
 

--- a/src/modsrc/smbnt.c
+++ b/src/modsrc/smbnt.c
@@ -1884,8 +1884,8 @@ int tryLogin(int hSocket, sLogin** psLogin, _SMBNT_DATA* _psSessionData, char* s
       sprintf(ErrorCode, "0x%6.6X:", SMBerr);
       (*psLogin)->pErrorMsg = malloc( strlen(ErrorCode) + strlen(pErrorMsg) + 1);
       memset((*psLogin)->pErrorMsg, 0, strlen(ErrorCode) + strlen(pErrorMsg) + 1);
-      strncpy((*psLogin)->pErrorMsg, ErrorCode, strlen(ErrorCode));
-      strncat((*psLogin)->pErrorMsg, pErrorMsg, strlen(pErrorMsg));
+      strcpy((*psLogin)->pErrorMsg, ErrorCode);
+      strcat((*psLogin)->pErrorMsg, pErrorMsg);
       iRet = MSTATE_EXITING;
       break;
     case 0x000022:  /* Valid password, no access to ADMIN$ (non-administative account) */
@@ -1915,8 +1915,8 @@ int tryLogin(int hSocket, sLogin** psLogin, _SMBNT_DATA* _psSessionData, char* s
       sprintf(ErrorCode, "0x%6.6X:", SMBerr);
       (*psLogin)->pErrorMsg = malloc( strlen(ErrorCode) + strlen(pErrorMsg) + 1);
       memset((*psLogin)->pErrorMsg, 0, strlen(ErrorCode) + strlen(pErrorMsg) + 1);
-      strncpy((*psLogin)->pErrorMsg, ErrorCode, strlen(ErrorCode));
-      strncat((*psLogin)->pErrorMsg, pErrorMsg, strlen(pErrorMsg));
+      strcpy((*psLogin)->pErrorMsg, ErrorCode);
+      strcat((*psLogin)->pErrorMsg, pErrorMsg);
       (*psLogin)->iResult = LOGIN_RESULT_ERROR;
       iRet = MSTATE_EXITING;
       break;

--- a/src/modsrc/smtp-vrfy.c
+++ b/src/modsrc/smtp-vrfy.c
@@ -144,9 +144,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);

--- a/src/modsrc/smtp.c
+++ b/src/modsrc/smtp.c
@@ -142,9 +142,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);
@@ -172,9 +170,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szDomain = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szDomain, 0, strlen(pOpt) + 1);
-          strncpy((char *) psSessionData->szDomain, pOpt, strlen(pOpt));
+          psSessionData->szDomain = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method DOMAIN requires value to be set.");

--- a/src/modsrc/snmp.c
+++ b/src/modsrc/snmp.c
@@ -162,9 +162,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option (%d/%d): %s", i+1, argc, pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);

--- a/src/modsrc/ssh.c
+++ b/src/modsrc/ssh.c
@@ -131,9 +131,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
     for (i=0; i<argc; i++) {
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", argv[i]);
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
 
       if (strcmp(pOpt, "BANNER") == 0)

--- a/src/modsrc/svn.c
+++ b/src/modsrc/svn.c
@@ -127,9 +127,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);
@@ -141,9 +139,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szBranch = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szBranch, 0, strlen(pOpt) + 1);
-          strncpy((char *)psSessionData->szBranch, pOpt, strlen(pOpt));
+          psSessionData->szBranch = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method BRANCH requires value to be set.");

--- a/src/modsrc/telnet.c
+++ b/src/modsrc/telnet.c
@@ -150,9 +150,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);
@@ -686,9 +684,7 @@ int tryLoginAS400(int hSocket, sLogin** psLogin, char* szLogin, char* szPassword
   {
     sprintf(szErrorMsg, "CPF1120 - User %s does not exist.", szUser); 
     writeError(ERR_ERROR, "[%s] %s", MODULE_NAME, szErrorMsg);
-    (*psLogin)->pErrorMsg = malloc( strlen(szErrorMsg) + 1 );
-    memset((*psLogin)->pErrorMsg, 0, strlen(szErrorMsg) + 1 );
-    strncpy((*psLogin)->pErrorMsg, szErrorMsg, strlen(szErrorMsg));
+    (*psLogin)->pErrorMsg = strdup(szErrorMsg);
     (*psLogin)->iResult = LOGIN_RESULT_ERROR;
     iRet = MSTATE_EXITING;
   }
@@ -696,9 +692,7 @@ int tryLoginAS400(int hSocket, sLogin** psLogin, char* szLogin, char* szPassword
   {
     strcpy(szErrorMsg, "CPF1116 - Next not valid sign-on attempt varies off device."); 
     writeError(ERR_ERROR, "[%s] %s", MODULE_NAME, szErrorMsg);
-    (*psLogin)->pErrorMsg = malloc( strlen(szErrorMsg) + 1 );
-    memset((*psLogin)->pErrorMsg, 0, strlen(szErrorMsg) + 1 );
-    strncpy((*psLogin)->pErrorMsg, szErrorMsg, strlen(szErrorMsg));
+    (*psLogin)->pErrorMsg = strdup(szErrorMsg);
     (*psLogin)->iResult = LOGIN_RESULT_FAIL;
     iRet = MSTATE_NEW;
   }
@@ -706,9 +700,7 @@ int tryLoginAS400(int hSocket, sLogin** psLogin, char* szLogin, char* szPassword
   {
     strcpy(szErrorMsg, "CPF1392 - Next not valid sign-on disables user profile."); 
     writeError(ERR_ERROR, "[%s] %s", MODULE_NAME, szErrorMsg);
-    (*psLogin)->pErrorMsg = malloc( strlen(szErrorMsg) + 1 );
-    memset((*psLogin)->pErrorMsg, 0, strlen(szErrorMsg) + 1 );
-    strncpy((*psLogin)->pErrorMsg, szErrorMsg, strlen(szErrorMsg));
+    (*psLogin)->pErrorMsg = strdup(szErrorMsg);
     (*psLogin)->iResult = LOGIN_RESULT_ERROR;
     iRet = MSTATE_EXITING;
   }
@@ -729,9 +721,7 @@ int tryLoginAS400(int hSocket, sLogin** psLogin, char* szLogin, char* szPassword
   {
     sprintf(szErrorMsg, "CPF1394 - User profile %s cannot sign on.", szUser); 
     writeError(ERR_ERROR, "[%s] %s", MODULE_NAME, szErrorMsg);
-    (*psLogin)->pErrorMsg = malloc( strlen(szErrorMsg) + 1 );
-    memset((*psLogin)->pErrorMsg, 0, strlen(szErrorMsg) + 1 );
-    strncpy((*psLogin)->pErrorMsg, szErrorMsg, strlen(szErrorMsg));
+    (*psLogin)->pErrorMsg = strdup(szErrorMsg);
     (*psLogin)->iResult = LOGIN_RESULT_ERROR;
     iRet = MSTATE_EXITING;
   }
@@ -739,9 +729,7 @@ int tryLoginAS400(int hSocket, sLogin** psLogin, char* szLogin, char* szPassword
   {
     sprintf(szErrorMsg, "CPF1118 - No password associated with user %s.", szUser); 
     writeError(ERR_ERROR, "[%s] %s", MODULE_NAME, szErrorMsg);
-    (*psLogin)->pErrorMsg = malloc( strlen(szErrorMsg) + 1 );
-    memset((*psLogin)->pErrorMsg, 0, strlen(szErrorMsg) + 1 );
-    strncpy((*psLogin)->pErrorMsg, szErrorMsg, strlen(szErrorMsg));
+    (*psLogin)->pErrorMsg = strdup(szErrorMsg);
     (*psLogin)->iResult = LOGIN_RESULT_SUCCESS;
     iRet = MSTATE_EXITING;
   }
@@ -749,9 +737,7 @@ int tryLoginAS400(int hSocket, sLogin** psLogin, char* szLogin, char* szPassword
   {
     strcpy(szErrorMsg, "CPF1109 - Not authorized to subsystem."); 
     writeError(ERR_ERROR, "[%s] %s", MODULE_NAME, szErrorMsg);
-    (*psLogin)->pErrorMsg = malloc( strlen(szErrorMsg) + 1 );
-    memset((*psLogin)->pErrorMsg, 0, strlen(szErrorMsg) + 1 );
-    strncpy((*psLogin)->pErrorMsg, szErrorMsg, strlen(szErrorMsg));
+    (*psLogin)->pErrorMsg = strdup(szErrorMsg);
     (*psLogin)->iResult = LOGIN_RESULT_SUCCESS;
     iRet = MSTATE_EXITING;
   }
@@ -759,9 +745,7 @@ int tryLoginAS400(int hSocket, sLogin** psLogin, char* szLogin, char* szPassword
   {
     strcpy(szErrorMsg, "CPF1110 - Not authorized to work station."); 
     writeError(ERR_ERROR, "[%s] %s", MODULE_NAME, szErrorMsg);
-    (*psLogin)->pErrorMsg = malloc( strlen(szErrorMsg) + 1 );
-    memset((*psLogin)->pErrorMsg, 0, strlen(szErrorMsg) + 1 );
-    strncpy((*psLogin)->pErrorMsg, szErrorMsg, strlen(szErrorMsg));
+    (*psLogin)->pErrorMsg = strdup(szErrorMsg);
     (*psLogin)->iResult = LOGIN_RESULT_SUCCESS;
     iRet = MSTATE_EXITING;
   }

--- a/src/modsrc/vnc.c
+++ b/src/modsrc/vnc.c
@@ -155,9 +155,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
  
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);
@@ -179,9 +177,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szDomain = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szDomain, 0, strlen(pOpt) + 1);
-          strncpy((char *) psSessionData->szDomain, pOpt, strlen(pOpt));
+          psSessionData->szDomain = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method DOMAIN requires value to be set.");

--- a/src/modsrc/web-form.c
+++ b/src/modsrc/web-form.c
@@ -143,9 +143,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);
@@ -157,9 +155,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szDir = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szDir, 0, strlen(pOpt) + 1);
-          strncpy(psSessionData->szDir, pOpt, strlen(pOpt));
+          psSessionData->szDir = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method FORM requires value to be set.");
@@ -171,9 +167,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szDenySignal= malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szDenySignal, 0, strlen(pOpt) + 1);
-          strncpy(psSessionData->szDenySignal, pOpt, strlen(pOpt));
+          psSessionData->szDenySignal= strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method DENY-SIGNAL requires value to be set.");
@@ -185,9 +179,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szFormData = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szFormData, 0, strlen(pOpt) + 1);
-          strncpy(psSessionData->szFormData, pOpt, strlen(pOpt));
+          psSessionData->szFormData = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method FORM-DATA requires value to be set.");
@@ -199,9 +191,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szUserAgent = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szUserAgent, 0, strlen(pOpt) + 1);
-          strncpy(psSessionData->szUserAgent, pOpt, strlen(pOpt));
+          psSessionData->szUserAgent = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method USER-AGENT requires value to be set.");
@@ -351,25 +341,19 @@ int initModule(_MODULE_DATA *_psSessionData, sLogin* _psLogin)
             pTemp = strtok_r(NULL, "&", &pStrtokSavePtr);
             if (pTemp != NULL)
             {
-              _psSessionData->szFormUser = malloc( strlen(pTemp) + 1 );
-              memset(_psSessionData->szFormUser, 0, strlen(pTemp) + 1);
-              strncpy(_psSessionData->szFormUser, pTemp, strlen(pTemp));
+              _psSessionData->szFormUser = strdup(pTemp);
             }
 
             pTemp = strtok_r(NULL, "&", &pStrtokSavePtr);
             if (pTemp != NULL)
             {
-              _psSessionData->szFormPass = malloc( strlen(pTemp) + 1);
-              memset(_psSessionData->szFormPass, 0, strlen(pTemp) + 1);
-              strncpy(_psSessionData->szFormPass, pTemp, strlen(pTemp));
+              _psSessionData->szFormPass = strdup(pTemp);
             }
 
             pTemp = strtok_r(NULL, "", &pStrtokSavePtr);
             if (pTemp != NULL)
             {
-              _psSessionData->szFormRest = malloc( strlen(pTemp) + 1 );
-              memset(_psSessionData->szFormRest, 0, strlen(pTemp) + 1);
-              strncpy(_psSessionData->szFormRest, pTemp, strlen(pTemp));
+              _psSessionData->szFormRest = strdup(pTemp);
             }
           }
 

--- a/src/modsrc/wrapper.c
+++ b/src/modsrc/wrapper.c
@@ -142,9 +142,7 @@ int go(sLogin* logins, int argc, char *argv[])
     writeError(ERR_DEBUG_MODULE, "OMG teh %s module has been called!!", MODULE_NAME);
 
     for (i=0; i<argc; i++) {
-      pOptTmp = malloc( strlen(argv[i]) + 1);
-      memset(pOptTmp, 0, strlen(argv[i]) + 1);
-      strncpy(pOptTmp, argv[i], strlen(argv[i]));
+      pOptTmp = strdup(argv[i]);
       writeError(ERR_DEBUG_MODULE, "Processing complete option: %s", pOptTmp);
       pOpt = strtok_r(pOptTmp, ":", &strtok_ptr);
       writeError(ERR_DEBUG_MODULE, "Processing option: %s", pOpt);
@@ -170,9 +168,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szCmd = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szCmd, 0, strlen(pOpt) + 1);
-          strncpy((char *)psSessionData->szCmd, pOpt, strlen(pOpt) + 1);
+          psSessionData->szCmd = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method PROG requires value to be set.");
@@ -184,9 +180,7 @@ int go(sLogin* logins, int argc, char *argv[])
 
         if ( pOpt )
         {
-          psSessionData->szCmdParam = malloc(strlen(pOpt) + 1);
-          memset(psSessionData->szCmdParam, 0, strlen(pOpt) + 1);
-          strncpy((char *)psSessionData->szCmdParam, pOpt, strlen(pOpt) + 1);
+          psSessionData->szCmdParam = strdup(pOpt);
         }
         else
           writeError(ERR_WARNING, "Method ARGS requires value to be set.");


### PR DESCRIPTION
The Debian package for Medusa compiles by default with `-D_FORTIFY_SOURCE=2 -O2`. This detects some cases in which `strncpy()` is called with its third parameter, `n`, being calculated from the source length. Generally speaking, parameter `n` should be based on the destination buffer size instead: if `n` is based on the source length it can result in a value greater than the size of the destination buffer and a buffer overflow will occur. This will trigger a compiler warning. The fix is to change `n` to be based on the destination buffer size.

However, in the cases for these patches, all uses of `strncat()` are preceeded by a correct `malloc()` call. The `malloc()` call is calculated on the source length, thus, the destination buffer size is also calculated from the source length. Not only this triggers the warning, but there is no way of using a destination buffer size without referencing the source length. At the same time, there is a guarantee that the source string will always fit in the destination buffer. This means that using simple `strcpy()` and `strcat()` calls would be correct, simpler and silence the warning at the same time.

In these patches I submit changes to silence the most obvious ones. In the first patch I refactor into `strdup()` which simplifies code even further. In the second one I refactor into a combination of `strcpy()` and `strcat()`.

The refactored code was originally correct. The changes should not introduce any kind of behavior change.