### PR TITLE
If another thread tested the last password for a user and selected th…

### DIFF
--- a/src/medusa.c
+++ b/src/medusa.c
@@ -1179,6 +1179,11 @@ int getNextNormalCredSet(sLogin *_psLogin, sCredentialSet *_psCredSet)
       {
         _psLogin->psUser = NULL;
       }
+      /* if another thread has already selected the next user, process that user */
+      else if ((_psLogin->psServer->psHost->psUserCurrent->iPassStatus != PL_DONE) && (_psLogin->psServer->psHost->psUserCurrent->iPassStatus != PASS_AUDIT_COMPLETE))
+      {
+        _psLogin->psUser = _psLogin->psServer->psHost->psUserCurrent;
+      }
       else
       {
         _psLogin->psUser = _psLogin->psServer->psHost->psUserCurrent->psUserNext;


### PR DESCRIPTION
If another thread tested the last password for a user and selected the next account, other threads should work on that new account as well when ready. This fixes an old bug where after the first user was done, we started processing users in parallel rather than sequentially.